### PR TITLE
use -march=native after 4009

### DIFF
--- a/linuxsupport.patch
+++ b/linuxsupport.patch
@@ -6,7 +6,7 @@ index 3a57356ab..d7ffae076 100644
          -Wmissing-declarations
          -Wno-attributes
          -Wno-unused-parameter
-+        -mcx16
++        -march=native
 +        -lboost_context
 +        -lfmt
      )

--- a/rice.patch
+++ b/rice.patch
@@ -6,8 +6,7 @@ index d7ffae076..a95185d9e 100644
          -Wmissing-declarations
          -Wno-attributes
          -Wno-unused-parameter
--        -mcx16
-+        -march=native
+         -march=native
 +        -Ofast
 +        -fuse-linker-plugin
 +        -flto


### PR DESCRIPTION
This makes the builds incapable of redistribution. However, 4009
causes performance issues when built generically.